### PR TITLE
Feature/remove remember me

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,16 @@ const main = async () => {
 
 void main();
 ```
+
+## FAQ
+
+### Login doesn't work
+
+Try to pass `headless: false` to `login` function and see what's happening in the browser.
+
+```typescript
+const credentials = await login({
+  phoneNumber: "600700800",
+  headless: false,
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biedronka-client",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Reverse engineered client for mobile Biedronka app",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/src/getAccessToken.ts
+++ b/src/getAccessToken.ts
@@ -63,7 +63,6 @@ export const login = async ({
     "https://konto.biedronka.pl/realms/loyalty/protocol/openid-connect/auth?response_type=code&client_id=cma20&redirect_uri=app%3A%2F%2Fcma20.biedronka.pl"
   );
   await page.getByRole("button", { name: /Accept/i }).click();
-  await page.getByLabel("Remember me").check();
   await page.getByLabel(/Phone number/i).fill(phoneNumber);
   await page.getByLabel(/Phone number/i).clear();
   await page.getByLabel(/Phone number/i).fill(phoneNumber);


### PR DESCRIPTION
Last week biedronka implemented a different login page where there is no longer "remember me" by which the script failed. 
The login page changes additionally with a subpage with personal data update, but the changes would be too advanced, and I don't have such an account that would skip this page, so I add such a quick fix, and the page with data update I recommend to click on non headles mode